### PR TITLE
Add deprecation message to CLI output

### DIFF
--- a/src/cosmica/cli/main.py
+++ b/src/cosmica/cli/main.py
@@ -20,7 +20,7 @@ def _version_callback(value: bool) -> None:  # noqa: FBT001
 
 @app.callback()
 def main(
-    version: Annotated[
+    _version: Annotated[
         bool | None,
         typer.Option("--version", help="Show version information", is_eager=True, callback=_version_callback),
     ] = None,


### PR DESCRIPTION
As we deprecate the TOML configuration, the CLI should be deprecated too.