### PR TITLE
Add gateway network building methods

### DIFF
--- a/src/cosmica/models/gateway.py
+++ b/src/cosmica/models/gateway.py
@@ -4,11 +4,40 @@ __all__ = [
     "Gateway",
     "GatewayOGS",
 ]
+import math
 from collections.abc import Hashable
 from dataclasses import dataclass, field
 from typing import override
 
 from .node import Node
+
+
+def _assert_finite(value: float, *, name: str) -> None:
+    assert math.isfinite(value), f"{name} must be finite."
+
+
+def _assert_in_range(value: float, *, name: str, lower: float, upper: float) -> None:
+    assert lower <= value <= upper, f"{name} must be in [{lower}, {upper}]."
+
+
+def _validate_gateway_fields(
+    *,
+    latitude: float,
+    longitude: float,
+    minimum_elevation: float,
+    altitude: float,
+    n_terminals: int,
+) -> None:
+    _assert_finite(latitude, name="latitude")
+    _assert_finite(longitude, name="longitude")
+    _assert_finite(minimum_elevation, name="minimum_elevation")
+    _assert_finite(altitude, name="altitude")
+
+    _assert_in_range(latitude, name="latitude", lower=-math.pi / 2, upper=math.pi / 2)
+    _assert_in_range(longitude, name="longitude", lower=-math.pi, upper=math.pi)
+    _assert_in_range(minimum_elevation, name="minimum_elevation", lower=0.0, upper=math.pi / 2)
+    assert isinstance(n_terminals, int), "n_terminals must be an integer."
+    assert n_terminals > 0, "n_terminals must be positive."
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -19,6 +48,15 @@ class Gateway[T: Hashable](Node[T]):
     minimum_elevation: float = field(compare=False)
     altitude: float = field(default=0.0, compare=False)
     n_terminals: int = field(default=1, compare=False)
+
+    def __post_init__(self) -> None:
+        _validate_gateway_fields(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            minimum_elevation=self.minimum_elevation,
+            altitude=self.altitude,
+            n_terminals=self.n_terminals,
+        )
 
     @classmethod
     @override
@@ -36,6 +74,19 @@ class GatewayOGS[T: Hashable](Node[T]):
     n_terminals: int = field(default=1, compare=False)
     aperture_size: float = field(default=1.0, compare=False)
     rytov_variance: float = field(default=0.5, compare=False)
+
+    def __post_init__(self) -> None:
+        _validate_gateway_fields(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            minimum_elevation=self.minimum_elevation,
+            altitude=self.altitude,
+            n_terminals=self.n_terminals,
+        )
+        _assert_finite(self.aperture_size, name="aperture_size")
+        _assert_finite(self.rytov_variance, name="rytov_variance")
+        assert self.aperture_size > 0.0, "aperture_size must be positive."
+        assert self.rytov_variance >= 0.0, "rytov_variance must be non-negative."
 
     @classmethod
     @override

--- a/src/cosmica/scenario/gateway_network.py
+++ b/src/cosmica/scenario/gateway_network.py
@@ -131,12 +131,8 @@ def _validate_gateway_map(gateway_map: Mapping[Hashable, Mapping[str, float | in
         _assert_real_in_range(lon_deg, "lon_deg", -180.0, 180.0, gateway_id)
         _assert_real_in_range(min_el_deg, "min_el_deg", 0.0, 90.0, gateway_id)
         if n_terminals is not None:
-            assert isinstance(n_terminals, Integral), (
-                f"Gateway {gateway_id} n_terminals must be an integer."
-            )
-            assert int(n_terminals) > 0, (
-                f"Gateway {gateway_id} n_terminals must be a positive integer."
-            )
+            assert isinstance(n_terminals, Integral), f"Gateway {gateway_id} n_terminals must be an integer."
+            assert int(n_terminals) > 0, f"Gateway {gateway_id} n_terminals must be a positive integer."
 
         if "altitude" in specs:
             _assert_real_in_range(specs["altitude"], "altitude", -1e6, 1e6, gateway_id)
@@ -145,7 +141,11 @@ def _validate_gateway_map(gateway_map: Mapping[Hashable, Mapping[str, float | in
 
 
 def _assert_real_in_range(
-    value: float, name: str, min_value: float, max_value: float, gateway_id: Hashable,
+    value: float,
+    name: str,
+    min_value: float,
+    max_value: float,
+    gateway_id: Hashable,
 ) -> None:
     assert isinstance(value, Real), f"Gateway {gateway_id} {name} must be a real number."
     assert np.isfinite(float(value)), f"Gateway {gateway_id} {name} must be finite."

--- a/src/cosmica/scenario/gateway_network.py
+++ b/src/cosmica/scenario/gateway_network.py
@@ -68,9 +68,7 @@ def build_default_gateway_network(
         assert not invalid_ids, f"Unknown gateway ids: {sorted(invalid_ids)}."
         selected_ids = list(indexes)
     else:
-        assert 1 <= n_stations <= len(DEFAULT_GATEWAYS), (
-            f"n_stations must be between 1 and {len(DEFAULT_GATEWAYS)}."
-        )
+        assert 1 <= n_stations <= len(DEFAULT_GATEWAYS), f"n_stations must be between 1 and {len(DEFAULT_GATEWAYS)}."
         selected_ids = list(sorted(DEFAULT_GATEWAYS))[:n_stations]
 
     gateway_map = {gateway_id: DEFAULT_GATEWAYS[gateway_id] for gateway_id in selected_ids}
@@ -139,7 +137,9 @@ def _validate_gateway_map(gateway_map: Mapping[Hashable, Mapping[str, Real | int
             _assert_real_in_range(specs["altitude_m"], "altitude_m", -1e6, 1e6, gateway_id)
 
 
-def _assert_real_in_range(value: Real | int, name: str, min_value: float, max_value: float, gateway_id: Hashable) -> None:
+def _assert_real_in_range(
+    value: Real | int, name: str, min_value: float, max_value: float, gateway_id: Hashable
+) -> None:
     assert isinstance(value, Real), f"Gateway {gateway_id} {name} must be a real number."
     assert np.isfinite(value), f"Gateway {gateway_id} {name} must be finite."
     assert min_value <= float(value) <= max_value, (

--- a/src/cosmica/scenario/gateway_network.py
+++ b/src/cosmica/scenario/gateway_network.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+__all__ = [
+    "DEFAULT_GATEWAYS",
+    "build_default_gateway_network",
+    "build_gateway_network",
+]
+from collections.abc import Collection, Hashable, Mapping
+from numbers import Integral, Real
+from typing import Annotated
+
+import numpy as np
+from typing_extensions import Doc
+
+from cosmica.models import Gateway
+
+DEFAULT_GATEWAYS = {
+    0: {  # Tokyo, Japan
+        "lat_deg": 36.0,
+        "lon_deg": 139.0,
+        "min_el_deg": 30.0,
+        "n_terminals": 1,
+    },
+    1: {  # California, USA
+        "lat_deg": 40.0,
+        "lon_deg": -120,
+        "min_el_deg": 30.0,
+        "n_terminals": 1,
+    },
+    2: {  # Nagasaki, Japan
+        "lat_deg": 33,
+        "lon_deg": 130,
+        "min_el_deg": 30.0,
+        "n_terminals": 1,
+    },
+    3: {  # Switzerland
+        "lat_deg": 47.0,
+        "lon_deg": 9.0,
+        "min_el_deg": 30.0,
+        "n_terminals": 1,
+    },
+    4: {  # Quebec, Canada
+        "lat_deg": 47.0,
+        "lon_deg": -70.0,
+        "min_el_deg": 30.0,
+        "n_terminals": 1,
+    },
+}
+
+_REQUIRED_FIELDS: frozenset[str] = frozenset({"lat_deg", "lon_deg", "min_el_deg"})
+
+
+def build_default_gateway_network(
+    n_stations: Annotated[int, Doc("Number of default gateways to include. Ignored if indexes is provided.")] = 5,
+    indexes: Annotated[
+        Collection[int] | None,
+        Doc("Optional subset of default gateway IDs to include."),
+    ] = None,
+) -> list[Gateway]:
+    """Build a list of default gateways.
+
+    If `indexes` is provided, only those IDs are included. Otherwise the first
+    `n_stations` default gateways are returned in key order.
+    """
+    if indexes is not None:
+        assert len(indexes) > 0, "indexes must be non-empty when provided."
+        invalid_ids = [idx for idx in indexes if idx not in DEFAULT_GATEWAYS]
+        assert not invalid_ids, f"Unknown gateway ids: {sorted(invalid_ids)}."
+        selected_ids = list(indexes)
+    else:
+        assert 1 <= n_stations <= len(DEFAULT_GATEWAYS), (
+            f"n_stations must be between 1 and {len(DEFAULT_GATEWAYS)}."
+        )
+        selected_ids = list(sorted(DEFAULT_GATEWAYS))[:n_stations]
+
+    gateway_map = {gateway_id: DEFAULT_GATEWAYS[gateway_id] for gateway_id in selected_ids}
+    return build_gateway_network(gateway_map)
+
+
+def build_gateway_network(
+    gateway_map: Annotated[
+        Mapping[Hashable, Mapping[str, Real | int]],
+        Doc("Mapping of gateway ID to gateway parameters."),
+    ],
+) -> list[Gateway]:
+    """Build a list of gateways from a mapping.
+
+    Required fields for each gateway:
+    - `lat_deg`: Latitude in degrees (-90 to 90).
+    - `lon_deg`: Longitude in degrees (-180 to 180).
+    - `min_el_deg`: Minimum elevation angle in degrees (0 to 90).
+
+    Optional fields:
+    - `altitude` or `altitude_m`: Gateway altitude in meters.
+    - `n_terminals`: Number of terminals (positive integer).
+    """
+    _validate_gateway_map(gateway_map)
+
+    gateway_list: list[Gateway] = []
+    for gateway_id, specs in gateway_map.items():
+        altitude = specs.get("altitude", specs.get("altitude_m", 0.0))
+        n_terminals = specs.get("n_terminals", 1)
+        gateway_list.append(
+            Gateway(
+                id=gateway_id,
+                latitude=np.deg2rad(float(specs["lat_deg"])),
+                longitude=np.deg2rad(float(specs["lon_deg"])),
+                minimum_elevation=np.deg2rad(float(specs["min_el_deg"])),
+                altitude=float(altitude),
+                n_terminals=int(n_terminals),
+            ),
+        )
+    return gateway_list
+
+
+def _validate_gateway_map(gateway_map: Mapping[Hashable, Mapping[str, Real | int]]) -> None:
+    assert len(gateway_map) > 0, "gateway_map must contain at least one gateway."
+    for gateway_id, specs in gateway_map.items():
+        assert isinstance(specs, Mapping), f"Gateway {gateway_id} parameters must be a mapping."
+        missing = _REQUIRED_FIELDS.difference(specs.keys())
+        assert not missing, f"Gateway {gateway_id} missing required fields: {sorted(missing)}."
+
+        lat_deg = specs["lat_deg"]
+        lon_deg = specs["lon_deg"]
+        min_el_deg = specs["min_el_deg"]
+        n_terminals = specs.get("n_terminals")
+
+        _assert_real_in_range(lat_deg, "lat_deg", -90.0, 90.0, gateway_id)
+        _assert_real_in_range(lon_deg, "lon_deg", -180.0, 180.0, gateway_id)
+        _assert_real_in_range(min_el_deg, "min_el_deg", 0.0, 90.0, gateway_id)
+        if n_terminals is not None:
+            assert isinstance(n_terminals, Integral) and int(n_terminals) > 0, (
+                f"Gateway {gateway_id} n_terminals must be a positive integer."
+            )
+
+        if "altitude" in specs:
+            _assert_real_in_range(specs["altitude"], "altitude", -1e6, 1e6, gateway_id)
+        if "altitude_m" in specs:
+            _assert_real_in_range(specs["altitude_m"], "altitude_m", -1e6, 1e6, gateway_id)
+
+
+def _assert_real_in_range(value: Real | int, name: str, min_value: float, max_value: float, gateway_id: Hashable) -> None:
+    assert isinstance(value, Real), f"Gateway {gateway_id} {name} must be a real number."
+    assert np.isfinite(value), f"Gateway {gateway_id} {name} must be finite."
+    assert min_value <= float(value) <= max_value, (
+        f"Gateway {gateway_id} {name} must be between {min_value} and {max_value}."
+    )

--- a/src/cosmica/scenario/gateway_network.py
+++ b/src/cosmica/scenario/gateway_network.py
@@ -1,87 +1,21 @@
 from __future__ import annotations
 
 __all__ = [
-    "DEFAULT_GATEWAYS",
     "build_default_gateway_network",
-    "build_gateway_network",
 ]
-from collections.abc import Collection, Hashable, Mapping
-from typing import Annotated, cast
 
 import numpy as np
-from typing_extensions import Doc
 
 from cosmica.models import Gateway
 
-DEFAULT_GATEWAYS: list[Gateway[int]] = [
-    Gateway(id=0, latitude=np.deg2rad(36.0), longitude=np.deg2rad(139.0), minimum_elevation=np.deg2rad(30.0)),
-    Gateway(id=1, latitude=np.deg2rad(40.0), longitude=np.deg2rad(-120.0), minimum_elevation=np.deg2rad(30.0)),
-    Gateway(id=2, latitude=np.deg2rad(33.0), longitude=np.deg2rad(130.0), minimum_elevation=np.deg2rad(30.0)),
-    Gateway(id=3, latitude=np.deg2rad(47.0), longitude=np.deg2rad(9.0), minimum_elevation=np.deg2rad(30.0)),
-    Gateway(id=4, latitude=np.deg2rad(47.0), longitude=np.deg2rad(-70.0), minimum_elevation=np.deg2rad(30.0)),
-]
 
-_REQUIRED_FIELDS: frozenset[str] = frozenset({"lat_deg", "lon_deg", "min_el_deg"})
-
-
-def build_default_gateway_network(
-    n_stations: Annotated[
-        int,
-        Doc("Number of default gateways to include. Ignored when indexes is provided."),
-    ] = 5,
-    indexes: Annotated[
-        Collection[int] | None,
-        Doc("Optional subset of default gateway IDs to include."),
-    ] = None,
-) -> list[Gateway]:
+def build_default_gateway_network() -> list[Gateway]:
     """Build a list of default gateways.
-
-    If `indexes` is provided, only those IDs are included. Otherwise the first
-    `n_stations` default gateways are returned in key order.
     """
-    if indexes is not None:
-        assert len(indexes) > 0, "indexes must be non-empty when provided."
-        default_gateway_by_id = {gateway.id: gateway for gateway in DEFAULT_GATEWAYS}
-        invalid_ids = [idx for idx in indexes if idx not in default_gateway_by_id]
-        assert not invalid_ids, f"Unknown gateway ids: {sorted(invalid_ids)}."
-        return [default_gateway_by_id[gateway_id] for gateway_id in indexes]
-    else:
-        assert 1 <= n_stations <= len(DEFAULT_GATEWAYS), f"n_stations must be between 1 and {len(DEFAULT_GATEWAYS)}."
-        return list(DEFAULT_GATEWAYS[:n_stations])
-
-
-def build_gateway_network(
-    gateway_map: Annotated[
-        Mapping[Hashable, Mapping[str, float | int]],
-        Doc("Mapping of gateway ID to gateway parameters."),
-    ],
-) -> list[Gateway]:
-    """Build a list of gateways from a mapping.
-
-    Required fields for each gateway:
-    - `lat_deg`: Latitude in degrees (-90 to 90).
-    - `lon_deg`: Longitude in degrees (-180 to 180).
-    - `min_el_deg`: Minimum elevation angle in degrees (0 to 90).
-
-    Optional fields:
-    - `altitude` or `altitude_m`: Gateway altitude in meters.
-    - `n_terminals`: Number of terminals (positive integer).
-    """
-    assert len(gateway_map) > 0, "gateway_map must contain at least one gateway."
-    gateway_list: list[Gateway] = []
-    for gateway_id, specs in gateway_map.items():
-        assert isinstance(specs, Mapping), f"Gateway {gateway_id} parameters must be a mapping."
-        missing = _REQUIRED_FIELDS.difference(specs.keys())
-        assert not missing, f"Gateway {gateway_id} missing required fields: {sorted(missing)}."
-        n_terminals = cast("int", specs.get("n_terminals", 1))
-        gateway_list.append(
-            Gateway(
-                id=gateway_id,
-                latitude=np.deg2rad(float(specs["lat_deg"])),
-                longitude=np.deg2rad(float(specs["lon_deg"])),
-                minimum_elevation=np.deg2rad(float(specs["min_el_deg"])),
-                altitude=float(specs.get("altitude", specs.get("altitude_m", 0.0))),
-                n_terminals=n_terminals,
-            ),
-        )
-    return gateway_list
+    return [
+        Gateway(id=0, latitude=np.deg2rad(36.0), longitude=np.deg2rad(139.0), minimum_elevation=np.deg2rad(30.0)),
+        Gateway(id=1, latitude=np.deg2rad(40.0), longitude=np.deg2rad(-120.0), minimum_elevation=np.deg2rad(30.0)),
+        Gateway(id=2, latitude=np.deg2rad(33.0), longitude=np.deg2rad(130.0), minimum_elevation=np.deg2rad(30.0)),
+        Gateway(id=3, latitude=np.deg2rad(47.0), longitude=np.deg2rad(9.0), minimum_elevation=np.deg2rad(30.0)),
+        Gateway(id=4, latitude=np.deg2rad(47.0), longitude=np.deg2rad(-70.0), minimum_elevation=np.deg2rad(30.0)),
+    ]

--- a/src/cosmica/scenario/gateway_network.py
+++ b/src/cosmica/scenario/gateway_network.py
@@ -10,8 +10,7 @@ from cosmica.models import Gateway
 
 
 def build_default_gateway_network() -> list[Gateway]:
-    """Build a list of default gateways.
-    """
+    """Build a list of default gateways."""
     return [
         Gateway(id=0, latitude=np.deg2rad(36.0), longitude=np.deg2rad(139.0), minimum_elevation=np.deg2rad(30.0)),
         Gateway(id=1, latitude=np.deg2rad(40.0), longitude=np.deg2rad(-120.0), minimum_elevation=np.deg2rad(30.0)),

--- a/src/cosmica/scenario/gateway_network.py
+++ b/src/cosmica/scenario/gateway_network.py
@@ -6,52 +6,29 @@ __all__ = [
     "build_gateway_network",
 ]
 from collections.abc import Collection, Hashable, Mapping
-from numbers import Integral, Real
-from typing import Annotated
+from typing import Annotated, cast
 
 import numpy as np
 from typing_extensions import Doc
 
 from cosmica.models import Gateway
 
-DEFAULT_GATEWAYS: dict[int, dict[str, float | int]] = {
-    0: {  # Tokyo, Japan
-        "lat_deg": 36.0,
-        "lon_deg": 139.0,
-        "min_el_deg": 30.0,
-        "n_terminals": 1,
-    },
-    1: {  # California, USA
-        "lat_deg": 40.0,
-        "lon_deg": -120,
-        "min_el_deg": 30.0,
-        "n_terminals": 1,
-    },
-    2: {  # Nagasaki, Japan
-        "lat_deg": 33,
-        "lon_deg": 130,
-        "min_el_deg": 30.0,
-        "n_terminals": 1,
-    },
-    3: {  # Switzerland
-        "lat_deg": 47.0,
-        "lon_deg": 9.0,
-        "min_el_deg": 30.0,
-        "n_terminals": 1,
-    },
-    4: {  # Quebec, Canada
-        "lat_deg": 47.0,
-        "lon_deg": -70.0,
-        "min_el_deg": 30.0,
-        "n_terminals": 1,
-    },
-}
+DEFAULT_GATEWAYS: list[Gateway[int]] = [
+    Gateway(id=0, latitude=np.deg2rad(36.0), longitude=np.deg2rad(139.0), minimum_elevation=np.deg2rad(30.0)),
+    Gateway(id=1, latitude=np.deg2rad(40.0), longitude=np.deg2rad(-120.0), minimum_elevation=np.deg2rad(30.0)),
+    Gateway(id=2, latitude=np.deg2rad(33.0), longitude=np.deg2rad(130.0), minimum_elevation=np.deg2rad(30.0)),
+    Gateway(id=3, latitude=np.deg2rad(47.0), longitude=np.deg2rad(9.0), minimum_elevation=np.deg2rad(30.0)),
+    Gateway(id=4, latitude=np.deg2rad(47.0), longitude=np.deg2rad(-70.0), minimum_elevation=np.deg2rad(30.0)),
+]
 
 _REQUIRED_FIELDS: frozenset[str] = frozenset({"lat_deg", "lon_deg", "min_el_deg"})
 
 
 def build_default_gateway_network(
-    n_stations: Annotated[int, Doc("Number of default gateways to include. Ignored if indexes is provided.")] = 5,
+    n_stations: Annotated[
+        int,
+        Doc("Number of default gateways to include. Ignored when indexes is provided."),
+    ] = 5,
     indexes: Annotated[
         Collection[int] | None,
         Doc("Optional subset of default gateway IDs to include."),
@@ -64,17 +41,13 @@ def build_default_gateway_network(
     """
     if indexes is not None:
         assert len(indexes) > 0, "indexes must be non-empty when provided."
-        invalid_ids = [idx for idx in indexes if idx not in DEFAULT_GATEWAYS]
+        default_gateway_by_id = {gateway.id: gateway for gateway in DEFAULT_GATEWAYS}
+        invalid_ids = [idx for idx in indexes if idx not in default_gateway_by_id]
         assert not invalid_ids, f"Unknown gateway ids: {sorted(invalid_ids)}."
-        selected_ids = list(indexes)
+        return [default_gateway_by_id[gateway_id] for gateway_id in indexes]
     else:
         assert 1 <= n_stations <= len(DEFAULT_GATEWAYS), f"n_stations must be between 1 and {len(DEFAULT_GATEWAYS)}."
-        selected_ids = sorted(DEFAULT_GATEWAYS)[:n_stations]
-
-    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
-        gateway_id: DEFAULT_GATEWAYS[gateway_id] for gateway_id in selected_ids
-    }
-    return build_gateway_network(gateway_map)
+        return list(DEFAULT_GATEWAYS[:n_stations])
 
 
 def build_gateway_network(
@@ -94,61 +67,21 @@ def build_gateway_network(
     - `altitude` or `altitude_m`: Gateway altitude in meters.
     - `n_terminals`: Number of terminals (positive integer).
     """
-    _validate_gateway_map(gateway_map)
-
+    assert len(gateway_map) > 0, "gateway_map must contain at least one gateway."
     gateway_list: list[Gateway] = []
     for gateway_id, specs in gateway_map.items():
-        altitude = specs.get("altitude", specs.get("altitude_m", 0.0))
-        n_terminals_raw = specs.get("n_terminals", 1)
-        assert isinstance(n_terminals_raw, Integral)
-        n_terminals = int(n_terminals_raw)
+        assert isinstance(specs, Mapping), f"Gateway {gateway_id} parameters must be a mapping."
+        missing = _REQUIRED_FIELDS.difference(specs.keys())
+        assert not missing, f"Gateway {gateway_id} missing required fields: {sorted(missing)}."
+        n_terminals = cast("int", specs.get("n_terminals", 1))
         gateway_list.append(
             Gateway(
                 id=gateway_id,
                 latitude=np.deg2rad(float(specs["lat_deg"])),
                 longitude=np.deg2rad(float(specs["lon_deg"])),
                 minimum_elevation=np.deg2rad(float(specs["min_el_deg"])),
-                altitude=float(altitude),
-                n_terminals=int(n_terminals),
+                altitude=float(specs.get("altitude", specs.get("altitude_m", 0.0))),
+                n_terminals=n_terminals,
             ),
         )
     return gateway_list
-
-
-def _validate_gateway_map(gateway_map: Mapping[Hashable, Mapping[str, float | int]]) -> None:
-    assert len(gateway_map) > 0, "gateway_map must contain at least one gateway."
-    for gateway_id, specs in gateway_map.items():
-        assert isinstance(specs, Mapping), f"Gateway {gateway_id} parameters must be a mapping."
-        missing = _REQUIRED_FIELDS.difference(specs.keys())
-        assert not missing, f"Gateway {gateway_id} missing required fields: {sorted(missing)}."
-
-        lat_deg = specs["lat_deg"]
-        lon_deg = specs["lon_deg"]
-        min_el_deg = specs["min_el_deg"]
-        n_terminals = specs.get("n_terminals")
-
-        _assert_real_in_range(lat_deg, "lat_deg", -90.0, 90.0, gateway_id)
-        _assert_real_in_range(lon_deg, "lon_deg", -180.0, 180.0, gateway_id)
-        _assert_real_in_range(min_el_deg, "min_el_deg", 0.0, 90.0, gateway_id)
-        if n_terminals is not None:
-            assert isinstance(n_terminals, Integral), f"Gateway {gateway_id} n_terminals must be an integer."
-            assert int(n_terminals) > 0, f"Gateway {gateway_id} n_terminals must be a positive integer."
-
-        if "altitude" in specs:
-            _assert_real_in_range(specs["altitude"], "altitude", -1e6, 1e6, gateway_id)
-        if "altitude_m" in specs:
-            _assert_real_in_range(specs["altitude_m"], "altitude_m", -1e6, 1e6, gateway_id)
-
-
-def _assert_real_in_range(
-    value: float,
-    name: str,
-    min_value: float,
-    max_value: float,
-    gateway_id: Hashable,
-) -> None:
-    assert isinstance(value, Real), f"Gateway {gateway_id} {name} must be a real number."
-    assert np.isfinite(float(value)), f"Gateway {gateway_id} {name} must be finite."
-    assert min_value <= float(value) <= max_value, (
-        f"Gateway {gateway_id} {name} must be between {min_value} and {max_value}."
-    )

--- a/tests/models/test_gateway.py
+++ b/tests/models/test_gateway.py
@@ -1,0 +1,27 @@
+from typing import cast
+
+import numpy as np
+import pytest
+
+from cosmica.models import Gateway
+
+
+def test_gateway_validation_rejects_invalid_latitude() -> None:
+    with pytest.raises(AssertionError):
+        Gateway(
+            id=0,
+            latitude=np.deg2rad(120.0),
+            longitude=np.deg2rad(0.0),
+            minimum_elevation=np.deg2rad(10.0),
+        )
+
+
+def test_gateway_validation_rejects_non_integer_terminals() -> None:
+    with pytest.raises(AssertionError):
+        Gateway(
+            id=0,
+            latitude=np.deg2rad(10.0),
+            longitude=np.deg2rad(0.0),
+            minimum_elevation=np.deg2rad(10.0),
+            n_terminals=cast("int", 1.5),
+        )

--- a/tests/scenario/test_gateway_network.py
+++ b/tests/scenario/test_gateway_network.py
@@ -1,5 +1,10 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Mapping
 
 from cosmica.models import Gateway
 from cosmica.scenario.gateway_network import DEFAULT_GATEWAYS, build_default_gateway_network, build_gateway_network
@@ -23,7 +28,7 @@ def test_build_default_gateway_network_indexes() -> None:
 
 
 def test_build_gateway_network_optional_n_terminals() -> None:
-    gateway_map = {
+    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
         "gw-1": {
             "lat_deg": 10.0,
             "lon_deg": 20.0,
@@ -36,7 +41,7 @@ def test_build_gateway_network_optional_n_terminals() -> None:
 
 
 def test_build_gateway_network_converts_degrees_to_radians() -> None:
-    gateway_map = {
+    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
         0: {
             "lat_deg": 45.0,
             "lon_deg": -90.0,
@@ -55,7 +60,7 @@ def test_build_gateway_network_converts_degrees_to_radians() -> None:
 
 
 def test_build_gateway_network_missing_required_field() -> None:
-    gateway_map = {
+    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
         0: {
             "lat_deg": 45.0,
             "lon_deg": -90.0,
@@ -66,7 +71,7 @@ def test_build_gateway_network_missing_required_field() -> None:
 
 
 def test_build_gateway_network_invalid_n_terminals() -> None:
-    gateway_map = {
+    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
         0: {
             "lat_deg": 45.0,
             "lon_deg": -90.0,

--- a/tests/scenario/test_gateway_network.py
+++ b/tests/scenario/test_gateway_network.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+from cosmica.models import Gateway
+from cosmica.scenario.gateway_network import DEFAULT_GATEWAYS, build_default_gateway_network, build_gateway_network
+
+
+def test_build_default_gateway_network_count() -> None:
+    gateways = build_default_gateway_network(n_stations=2)
+    assert len(gateways) == 2
+    assert all(isinstance(gateway, Gateway) for gateway in gateways)
+
+
+def test_build_default_gateway_network_indexes() -> None:
+    gateways = build_default_gateway_network(indexes=[1, 3])
+    gateway_ids = [gateway.id for gateway in gateways]
+    assert gateway_ids == [1, 3]
+    for gateway in gateways:
+        expected = DEFAULT_GATEWAYS[gateway.id]
+        assert np.isclose(gateway.latitude, np.deg2rad(expected["lat_deg"]))
+        assert np.isclose(gateway.longitude, np.deg2rad(expected["lon_deg"]))
+        assert np.isclose(gateway.minimum_elevation, np.deg2rad(expected["min_el_deg"]))
+
+
+def test_build_gateway_network_optional_n_terminals() -> None:
+    gateway_map = {
+        "gw-1": {
+            "lat_deg": 10.0,
+            "lon_deg": 20.0,
+            "min_el_deg": 5.0,
+        },
+    }
+    gateways = build_gateway_network(gateway_map)
+    assert len(gateways) == 1
+    assert gateways[0].n_terminals == 1
+
+
+def test_build_gateway_network_converts_degrees_to_radians() -> None:
+    gateway_map = {
+        0: {
+            "lat_deg": 45.0,
+            "lon_deg": -90.0,
+            "min_el_deg": 30.0,
+            "n_terminals": 2,
+            "altitude": 500.0,
+        },
+    }
+    gateways = build_gateway_network(gateway_map)
+    gateway = gateways[0]
+    assert np.isclose(gateway.latitude, np.deg2rad(45.0))
+    assert np.isclose(gateway.longitude, np.deg2rad(-90.0))
+    assert np.isclose(gateway.minimum_elevation, np.deg2rad(30.0))
+    assert gateway.altitude == 500.0
+    assert gateway.n_terminals == 2
+
+
+def test_build_gateway_network_missing_required_field() -> None:
+    gateway_map = {
+        0: {
+            "lat_deg": 45.0,
+            "lon_deg": -90.0,
+        },
+    }
+    with pytest.raises(AssertionError):
+        build_gateway_network(gateway_map)
+
+
+def test_build_gateway_network_invalid_n_terminals() -> None:
+    gateway_map = {
+        0: {
+            "lat_deg": 45.0,
+            "lon_deg": -90.0,
+            "min_el_deg": 30.0,
+            "n_terminals": 0,
+        },
+    }
+    with pytest.raises(AssertionError):
+        build_gateway_network(gateway_map)

--- a/tests/scenario/test_gateway_network.py
+++ b/tests/scenario/test_gateway_network.py
@@ -22,9 +22,9 @@ def test_build_default_gateway_network_indexes() -> None:
     assert gateway_ids == [1, 3]
     for gateway in gateways:
         expected = DEFAULT_GATEWAYS[gateway.id]
-        assert np.isclose(gateway.latitude, np.deg2rad(expected["lat_deg"]))
-        assert np.isclose(gateway.longitude, np.deg2rad(expected["lon_deg"]))
-        assert np.isclose(gateway.minimum_elevation, np.deg2rad(expected["min_el_deg"]))
+        assert np.isclose(gateway.latitude, expected.latitude)
+        assert np.isclose(gateway.longitude, expected.longitude)
+        assert np.isclose(gateway.minimum_elevation, expected.minimum_elevation)
 
 
 def test_build_gateway_network_optional_n_terminals() -> None:

--- a/tests/scenario/test_gateway_network.py
+++ b/tests/scenario/test_gateway_network.py
@@ -1,83 +1,36 @@
-from typing import TYPE_CHECKING
-
 import numpy as np
-import pytest
-
-if TYPE_CHECKING:
-    from collections.abc import Hashable, Mapping
 
 from cosmica.models import Gateway
-from cosmica.scenario.gateway_network import DEFAULT_GATEWAYS, build_default_gateway_network, build_gateway_network
+from cosmica.scenario.gateway_network import build_default_gateway_network
 
 
-def test_build_default_gateway_network_count() -> None:
-    gateways = build_default_gateway_network(n_stations=2)
-    assert len(gateways) == 2
-    assert all(isinstance(gateway, Gateway) for gateway in gateways)
+def test_build_default_gateway_network_returns_expected_gateways() -> None:
+    gateways = build_default_gateway_network()
+
+    expected_gateways = [
+        (0, 36.0, 139.0, 30.0),
+        (1, 40.0, -120.0, 30.0),
+        (2, 33.0, 130.0, 30.0),
+        (3, 47.0, 9.0, 30.0),
+        (4, 47.0, -70.0, 30.0),
+    ]
+
+    assert len(gateways) == len(expected_gateways)
+    for gateway, (gateway_id, lat_deg, lon_deg, min_el_deg) in zip(gateways, expected_gateways, strict=True):
+        assert isinstance(gateway, Gateway)
+        assert gateway.id == gateway_id
+        assert np.isclose(gateway.latitude, np.deg2rad(lat_deg))
+        assert np.isclose(gateway.longitude, np.deg2rad(lon_deg))
+        assert np.isclose(gateway.minimum_elevation, np.deg2rad(min_el_deg))
+        assert gateway.altitude == 0.0
+        assert gateway.n_terminals == 1
 
 
-def test_build_default_gateway_network_indexes() -> None:
-    gateways = build_default_gateway_network(indexes=[1, 3])
-    gateway_ids = [gateway.id for gateway in gateways]
-    assert gateway_ids == [1, 3]
-    for gateway in gateways:
-        expected = DEFAULT_GATEWAYS[gateway.id]
-        assert np.isclose(gateway.latitude, expected.latitude)
-        assert np.isclose(gateway.longitude, expected.longitude)
-        assert np.isclose(gateway.minimum_elevation, expected.minimum_elevation)
+def test_build_default_gateway_network_returns_a_new_list_each_time() -> None:
+    gateways = build_default_gateway_network()
+    gateways.pop()
 
+    rebuilt_gateways = build_default_gateway_network()
 
-def test_build_gateway_network_optional_n_terminals() -> None:
-    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
-        "gw-1": {
-            "lat_deg": 10.0,
-            "lon_deg": 20.0,
-            "min_el_deg": 5.0,
-        },
-    }
-    gateways = build_gateway_network(gateway_map)
-    assert len(gateways) == 1
-    assert gateways[0].n_terminals == 1
-
-
-def test_build_gateway_network_converts_degrees_to_radians() -> None:
-    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
-        0: {
-            "lat_deg": 45.0,
-            "lon_deg": -90.0,
-            "min_el_deg": 30.0,
-            "n_terminals": 2,
-            "altitude": 500.0,
-        },
-    }
-    gateways = build_gateway_network(gateway_map)
-    gateway = gateways[0]
-    assert np.isclose(gateway.latitude, np.deg2rad(45.0))
-    assert np.isclose(gateway.longitude, np.deg2rad(-90.0))
-    assert np.isclose(gateway.minimum_elevation, np.deg2rad(30.0))
-    assert gateway.altitude == 500.0
-    assert gateway.n_terminals == 2
-
-
-def test_build_gateway_network_missing_required_field() -> None:
-    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
-        0: {
-            "lat_deg": 45.0,
-            "lon_deg": -90.0,
-        },
-    }
-    with pytest.raises(AssertionError):
-        build_gateway_network(gateway_map)
-
-
-def test_build_gateway_network_invalid_n_terminals() -> None:
-    gateway_map: Mapping[Hashable, Mapping[str, float | int]] = {
-        0: {
-            "lat_deg": 45.0,
-            "lon_deg": -90.0,
-            "min_el_deg": 30.0,
-            "n_terminals": 0,
-        },
-    }
-    with pytest.raises(AssertionError):
-        build_gateway_network(gateway_map)
+    assert len(rebuilt_gateways) == 5
+    assert [gateway.id for gateway in rebuilt_gateways] == [0, 1, 2, 3, 4]


### PR DESCRIPTION
## Related issues
 - None
## Description
- Add functions for building list of gateways from a gateway map and building a default gateway network. The implemented functions provide a quick method to create a ground network. These functions may also be used to support CLI plots without using toml files.

## Test results
- Tests added and passing.

## Impact
- Enable quick creation of ground nodes which may support CLI plots and facilitate building a gateway network.
