### PR TITLE
Bump version to v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosmica"
-version = "0.4.0"
+version = "0.5.0"
 description = "COnstellation Satellite siMulator for optIcal CommunicAtion"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "cosmica"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "geopandas" },


### PR DESCRIPTION
We have a breaking change since v0.4.0, so we bump the minor version.

Breaking change:

- #87 

Deferred items for v0.6.0:

- #106
- Removal of `experimental_packet_routing` module