### PR TITLE
Remove deprecated license classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ authors = [
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: Apache Software License",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Remove the now-deprecated license classifiers.
We already support `license` and `license-files`, so removing the license classifiers is safe.