### PR TITLE
Add the optional generic type parameter to satellite and constellation classes

### DIFF
--- a/src/cosmica/models/constellation.py
+++ b/src/cosmica/models/constellation.py
@@ -21,15 +21,20 @@ use the dict key for structural queries and the satellite object itself
 
 from collections.abc import Hashable
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
-from .orbit import CircularSatelliteOrbitModel
+from .orbit import CircularSatelliteOrbitModel, SatelliteOrbitModel
 from .satellite import ConstellationSatellite
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class Constellation[SatelliteId: Hashable]:
+class Constellation[
+    SatelliteId: Hashable,
+    SatelliteNodeId: Hashable = Any,
+    SatelliteOrbitType: SatelliteOrbitModel = Any,
+]:
     """A constellation of satellites.
 
     `satellites` maps a structural identifier (`SatelliteId`) to each
@@ -42,7 +47,10 @@ class Constellation[SatelliteId: Hashable]:
     e.g., `Constellation[tuple[int, int]]`.
     """
 
-    satellites: dict[SatelliteId, ConstellationSatellite]
+    satellites: dict[
+        SatelliteId,
+        ConstellationSatellite[SatelliteNodeId, SatelliteOrbitType],
+    ]
 
 
 def build_walker_delta_constellation(

--- a/src/cosmica/models/satellite.py
+++ b/src/cosmica/models/satellite.py
@@ -7,7 +7,7 @@ __all__ = [
 from abc import ABC
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import override
+from typing import Any, override
 
 from .node import Node
 from .orbit import SatelliteOrbitModel
@@ -18,11 +18,10 @@ class Satellite[T: Hashable](Node[T], ABC): ...
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
-class ConstellationSatellite[T: Hashable](Satellite[T]):
+class ConstellationSatellite[T: Hashable, O: SatelliteOrbitModel = Any](Satellite[T]):
     id: T
 
-    # Allow none for backward compatibility.
-    orbit: SatelliteOrbitModel | None = field(hash=False, compare=False, default=None)
+    orbit: O = field(hash=False, compare=False)
 
     @classmethod
     @override
@@ -31,8 +30,10 @@ class ConstellationSatellite[T: Hashable](Satellite[T]):
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
-class UserSatellite[T: Hashable](Satellite[T]):
+class UserSatellite[T: Hashable, O: SatelliteOrbitModel = Any](Satellite[T]):
     id: T
+
+    orbit: O = field(hash=False, compare=False)
 
     @classmethod
     @override


### PR DESCRIPTION
## Summary

Adds generic type parameters to satellite and constellation models so callers can type the satellite node ID and orbit model more precisely.

## Breaking changes

- `ConstellationSatellite` now requires an `orbit` argument. The previous `orbit=None` default has been removed, so callers must provide an orbit model when constructing constellation satellites.
- `UserSatellite` now also requires an `orbit` argument. Callers that previously constructed user satellites with only an `id` must now pass an appropriate orbit model.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #124 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #123 
- <kbd>&nbsp;1&nbsp;</kbd> #122 
<!-- GitButler Footer Boundary Bottom -->
