### PR TITLE
Remove unused comm-link snapshot calculator

### DIFF
--- a/src/cosmica/comm_link/coordinator.py
+++ b/src/cosmica/comm_link/coordinator.py
@@ -34,37 +34,6 @@ class CommLinkCalculationCoordinator:
                 self.calculator_assignment,
             ), "All edge types must be unique."
 
-    def _calc(
-        self,
-        edges: Collection[tuple[Node, Node]],
-        *,
-        dynamics_data: DynamicsData,
-    ) -> dict[tuple[Node, Node], CommLinkPerformance]:
-        if any(isinstance(calculator, CommLinkCalculator) for calculator in self.calculator_assignment.values()):
-            msg = "Only memoryless calculators are supported. Use calc_time_series instead."
-            raise ValueError(msg)
-        # Categorize edges based on node types
-        edge_group_dd: defaultdict[EdgeType, list[tuple[Node, Node]]] = defaultdict(list)
-        for src, dst in edges:
-            edge_group_dd[type(src), type(dst)].append((src, dst))
-        edge_group = dict(edge_group_dd)
-
-        link_performance: dict[tuple[Node, Node], CommLinkPerformance] = {}
-        for edge_type, edges_of_type in edge_group.items():
-            if edge_type in self.calculator_assignment:
-                calculator = self.calculator_assignment[edge_type]
-                link_performance.update(calculator.calc(edges_of_type, dynamics_data=dynamics_data))
-            elif not self.directed and edge_type[::-1] in self.calculator_assignment:
-                calculator = self.calculator_assignment[(edge_type[1], edge_type[0])]
-                edges_inverted = [(dst, src) for src, dst in edges_of_type]
-                result_inverted = calculator.calc(edges_inverted, dynamics_data=dynamics_data)
-                link_performance.update({(src, dst): result_inverted[(dst, src)] for src, dst in edges_of_type})
-            else:
-                msg = f"No calculator found for edge type {edge_type}"
-                raise ValueError(msg)
-
-        return link_performance
-
     def calc(
         self,
         edges_time_series: Sequence[Collection[tuple[Node, Node]]],


### PR DESCRIPTION
## Summary
- Remove unused private `CommLinkCalculationCoordinator._calc` method
- Eliminate stale snapshot-calculation path that no longer matches the current calculator API

## Verification
- `just lint`
- `just test`

Note: `uv run ty check` still reports existing diagnostics unrelated to this removal; this change reduces the count by removing the coordinator diagnostics.