### PR TITLE
Remove unused inter-satellite capacity parameter

### DIFF
--- a/src/cosmica/comm_link/rate_distance_calculator.py
+++ b/src/cosmica/comm_link/rate_distance_calculator.py
@@ -25,7 +25,6 @@ class SatToSatBinaryCommLinkCalculatorWithRateCalc(MemorylessCommLinkCalculator[
     def __init__(
         self,
         *,
-        inter_satellite_link_capacity: float,
         max_inter_satellite_distance: float = float("inf"),
         lowest_altitude: float = 0.0,
         max_relative_angular_velocity: float = float("inf"),
@@ -36,7 +35,6 @@ class SatToSatBinaryCommLinkCalculatorWithRateCalc(MemorylessCommLinkCalculator[
         noise_figure: float = 4,
     ) -> None:
         self.max_inter_satellite_distance = max_inter_satellite_distance
-        self.inter_satellite_link_capacity = inter_satellite_link_capacity
         self.lowest_altitude = lowest_altitude
         self.max_relative_angular_velocity = max_relative_angular_velocity
         self.sun_exclusion_angle = sun_exclusion_angle


### PR DESCRIPTION
## Summary
- Remove the unused `inter_satellite_link_capacity` parameter from `SatToSatBinaryCommLinkCalculatorWithRateCalc`
- Keep the distance-based capacity calculation driven by `available_link_capacity`

## Breaking change
- Calls to `SatToSatBinaryCommLinkCalculatorWithRateCalc` must no longer pass `inter_satellite_link_capacity`

## Validation
- `just lint`
- `just test`

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #182 
- <kbd>&nbsp;1&nbsp;</kbd> #181 👈 
<!-- GitButler Footer Boundary Bottom -->

