### PR TITLE
Make Codecov coverage checks informational

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary

- add a repository-level Codecov configuration
- make the `codecov/project` and `codecov/patch` statuses informational
- continue reporting coverage without allowing coverage thresholds to block pull requests

See Codecov's documentation on [setting non-blocking status checks](https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks).

Coverage remains useful context for reviewers, but it is less important than functional tests, linting, type checking, and the other CI checks. Allowing a coverage threshold alone to mark a pull request as failed, as happened in #191 when patch coverage was 0%, can normalize red CI and make actionable failures easier to overlook. Informational statuses preserve the coverage report and its visibility while ensuring that CI failures continue to indicate problems in the blocking checks.

## AI assistance

- AI used: yes — an AI coding agent added and validated the Codecov configuration and drafted this pull request
- Human review of AI-assisted code: complete

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes; the `breaking change` label is applied