### PR TITLE
Enforce Earth occultation for inter-satellite links

### DIFF
--- a/src/cosmica/comm_link/geometric.py
+++ b/src/cosmica/comm_link/geometric.py
@@ -12,6 +12,7 @@ from cosmica.dtos import DynamicsData
 from cosmica.models import ConstellationSatellite, Gateway
 from cosmica.utils.constants import SPEED_OF_LIGHT
 from cosmica.utils.coordinates import ecef2aer
+from cosmica.utils.vector import is_line_segment_clear_of_earth
 
 from .base import CommLinkPerformance, MemorylessCommLinkCalculator
 
@@ -116,9 +117,17 @@ class GeometricCommLinkCalculator(MemorylessCommLinkCalculator[_NodeType, _NodeT
             -relative_angular_velocity_translational_eci - attitude_angular_velocities_eci[1],
         )
 
-        link_available = distance < self.max_inter_satellite_distance and all(
-            np.linalg.norm(relative_angular_velocity) < self.max_relative_angular_velocity
-            for relative_angular_velocity in relative_angular_velocities
+        link_available = (
+            distance < self.max_inter_satellite_distance
+            and is_line_segment_clear_of_earth(
+                positions_eci[0],
+                positions_eci[1],
+                lowest_altitude=self.lowest_altitude,
+            )
+            and all(
+                np.linalg.norm(relative_angular_velocity) < self.max_relative_angular_velocity
+                for relative_angular_velocity in relative_angular_velocities
+            )
         )
 
         return CommLinkPerformance(

--- a/src/cosmica/comm_link/rate_distance_calculator.py
+++ b/src/cosmica/comm_link/rate_distance_calculator.py
@@ -11,7 +11,7 @@ from typing_extensions import Doc
 from cosmica.dtos import DynamicsData
 from cosmica.models import Satellite
 from cosmica.utils.constants import BOLTZ_CONST, SPEED_OF_LIGHT
-from cosmica.utils.vector import angle_between, is_satellite_in_eclipse
+from cosmica.utils.vector import angle_between, is_line_segment_clear_of_earth, is_satellite_in_eclipse
 
 from .base import CommLinkPerformance, MemorylessCommLinkCalculator
 
@@ -142,6 +142,11 @@ class SatToSatBinaryCommLinkCalculatorWithRateCalc(MemorylessCommLinkCalculator[
 
         link_available = bool(
             distance < self.max_inter_satellite_distance
+            and is_line_segment_clear_of_earth(
+                positions_eci[0],
+                positions_eci[1],
+                lowest_altitude=self.lowest_altitude,
+            )
             and all(
                 float(np.linalg.norm(relative_angular_velocity)) < self.max_relative_angular_velocity
                 for relative_angular_velocity in relative_angular_velocities

--- a/src/cosmica/comm_link/sat_to_sat.py
+++ b/src/cosmica/comm_link/sat_to_sat.py
@@ -17,7 +17,13 @@ from typing_extensions import Doc
 from cosmica.dtos import DynamicsData
 from cosmica.models import OpticalCommunicationTerminal, Satellite, SatelliteTerminal
 from cosmica.utils.constants import SPEED_OF_LIGHT
-from cosmica.utils.vector import angle_between, is_satellite_in_eclipse, normalize, unit_vector_to_azimuth_elevation
+from cosmica.utils.vector import (
+    angle_between,
+    is_line_segment_clear_of_earth,
+    is_satellite_in_eclipse,
+    normalize,
+    unit_vector_to_azimuth_elevation,
+)
 
 from .base import CommLinkCalculator, CommLinkPerformance, MemorylessCommLinkCalculator
 
@@ -129,6 +135,11 @@ class SatToSatBinaryCommLinkCalculator(MemorylessCommLinkCalculator[Satellite, S
 
         link_available = bool(
             distance < self.max_inter_satellite_distance
+            and is_line_segment_clear_of_earth(
+                positions_eci[0],
+                positions_eci[1],
+                lowest_altitude=self.lowest_altitude,
+            )
             and all(
                 float(np.linalg.norm(relative_angular_velocity)) < self.max_relative_angular_velocity
                 for relative_angular_velocity in relative_angular_velocities
@@ -389,6 +400,11 @@ class OTC2OTCBinaryCommLinkCalculator(CommLinkCalculator[SatelliteTerminal, Sate
         ]
         link_available = bool(
             distance < self.max_inter_satellite_distance
+            and is_line_segment_clear_of_earth(
+                positions_eci[0],
+                positions_eci[1],
+                lowest_altitude=self.lowest_altitude,
+            )
             and all(
                 float(np.linalg.norm(relative_angular_velocity)) < self.max_relative_angular_velocity
                 for relative_angular_velocity in relative_angular_velocities

--- a/src/cosmica/utils/vector.py
+++ b/src/cosmica/utils/vector.py
@@ -5,6 +5,7 @@ __all__ = [
     "decompose_wrt_reference_vector",
     "generate_normal_vectors",
     "is_column_vector",
+    "is_line_segment_clear_of_earth",
     "is_satellite_in_eclipse",
     "normalize",
     "perturb_vector",
@@ -226,6 +227,26 @@ def closest_point_to_origin_on_line(
 
     # Compute r*
     return r1 + t * (r2 - r1)
+
+
+def is_line_segment_clear_of_earth(
+    r1: Annotated[npt.NDArray[np.floating], Doc("Position vector of the first segment endpoint.")],
+    r2: Annotated[npt.NDArray[np.floating], Doc("Position vector of the second segment endpoint.")],
+    *,
+    lowest_altitude: Annotated[float, Doc("Minimum permitted altitude above Earth's radius.")] = 0.0,
+) -> bool:
+    """Check whether a finite line segment maintains the required Earth clearance.
+
+    A segment whose closest point is exactly ``EARTH_RADIUS + lowest_altitude``
+    from Earth's center is considered clear.
+    """
+    closest_point = closest_point_to_origin_on_line(
+        r1,
+        r2,
+        extend_at_r1=False,
+        extend_at_r2=False,
+    )
+    return bool(np.linalg.norm(closest_point) >= EARTH_RADIUS + lowest_altitude)
 
 
 def azimuth_elevation_to_unit_vector(

--- a/tests/comm_link/test_directional_capacity.py
+++ b/tests/comm_link/test_directional_capacity.py
@@ -5,8 +5,10 @@ directed edge to the calculator registered for the exact (source type, destinati
 """
 
 from collections.abc import Callable
+from typing import Any, Literal
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from cosmica.comm_link import (
@@ -14,6 +16,7 @@ from cosmica.comm_link import (
     GatewayToSatBinaryCommLinkCalculator,
     MemorylessCommLinkCalculator,
     MemorylessCommLinkCalculatorWrapper,
+    OTC2OTCBinaryCommLinkCalculator,
     SatToGatewayBinaryCommLinkCalculator,
     SatToSatBinaryCommLinkCalculator,
     SatToSatBinaryCommLinkCalculatorWithRateCalc,
@@ -25,6 +28,7 @@ from cosmica.models import (
     ConstellationSatellite,
     Gateway,
     Satellite,
+    SatelliteTerminal,
 )
 from cosmica.utils.constants import EARTH_RADIUS
 
@@ -41,6 +45,18 @@ def _make_satellite(sat_id: int, phase_deg: float = 0.0) -> ConstellationSatelli
             phase_at_epoch=np.deg2rad(phase_deg),
             epoch=EPOCH,
         ),
+    )
+
+
+def _make_satellite_terminal(sat_id: int) -> SatelliteTerminal[int]:
+    return SatelliteTerminal(
+        id=sat_id,
+        terminal_id=sat_id,
+        azimuth_min=-np.pi,
+        azimuth_max=np.pi,
+        elevation_min=-np.pi / 2,
+        elevation_max=np.pi / 2,
+        angular_velocity_max=float("inf"),
     )
 
 
@@ -229,6 +245,131 @@ class TestSatToSatDirectionalDispatch:
         # Geometry (delay / availability) is direction-independent
         assert performance[(sat_a, sat_b)]["delay"] == performance[(sat_b, sat_a)]["delay"]
         assert performance[(sat_a, sat_b)]["link_available"] == performance[(sat_b, sat_a)]["link_available"]
+
+
+type _SatToSatCalculatorKind = Literal["binary", "rate_calc", "geometric"]
+
+
+_EARTH_CLEARANCE_CASES = [
+    pytest.param(
+        (
+            np.array([EARTH_RADIUS + 1000e3, 0.0, 0.0]),
+            np.array([-(EARTH_RADIUS + 1000e3), 0.0, 0.0]),
+        ),
+        0.0,
+        False,
+        id="opposite-sides-of-earth",
+    ),
+    pytest.param(
+        (
+            np.array([-1000e3, EARTH_RADIUS + 500e3, 0.0]),
+            np.array([1000e3, EARTH_RADIUS + 500e3, 0.0]),
+        ),
+        500e3,
+        True,
+        id="exact-threshold-is-clear",
+    ),
+    pytest.param(
+        (
+            np.array([-1000e3, EARTH_RADIUS + 500e3, 0.0]),
+            np.array([1000e3, EARTH_RADIUS + 500e3, 0.0]),
+        ),
+        500e3 + 1.0,
+        False,
+        id="below-configured-threshold",
+    ),
+    pytest.param(
+        (
+            np.array([EARTH_RADIUS + 200e3, 0.0, 0.0]),
+            np.array([EARTH_RADIUS + 300e3, 0.0, 0.0]),
+        ),
+        100e3,
+        True,
+        id="finite-segment-does-not-extend-through-earth",
+    ),
+]
+
+
+def _make_sat_to_sat_calculator(
+    kind: _SatToSatCalculatorKind,
+    *,
+    lowest_altitude: float,
+) -> MemorylessCommLinkCalculator[Any, Any]:
+    match kind:
+        case "binary":
+            return SatToSatBinaryCommLinkCalculator(
+                link_capacity=10e9,
+                lowest_altitude=lowest_altitude,
+            )
+        case "rate_calc":
+            return SatToSatBinaryCommLinkCalculatorWithRateCalc(
+                available_link_capacity=10e9,
+                lna_gain=30.0,
+                lowest_altitude=lowest_altitude,
+            )
+        case "geometric":
+            with pytest.warns(DeprecationWarning, match="GeometricCommLinkCalculator is deprecated"):
+                return GeometricCommLinkCalculator(
+                    inter_satellite_link_capacity=10e9,
+                    satellite_to_gateway_link_capacity=5e9,
+                    lowest_altitude=lowest_altitude,
+                )
+
+
+@pytest.mark.parametrize("kind", ["binary", "rate_calc", "geometric"])
+@pytest.mark.parametrize(("positions_eci", "lowest_altitude", "expected_available"), _EARTH_CLEARANCE_CASES)
+def test_memoryless_calculators_enforce_finite_segment_clearance(
+    kind: _SatToSatCalculatorKind,
+    positions_eci: tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]],
+    lowest_altitude: float,
+    *,
+    expected_available: bool,
+) -> None:
+    sat_a = _make_satellite(1)
+    sat_b = _make_satellite(2)
+    dynamics_data = _make_snapshot_dynamics_data(
+        position_eci={sat_a: positions_eci[0], sat_b: positions_eci[1]},
+    )
+    calculator = _make_sat_to_sat_calculator(kind, lowest_altitude=lowest_altitude)
+
+    performance = calculator.calc(
+        edges=[(sat_a, sat_b)],
+        dynamics_data=dynamics_data,
+        rng=np.random.default_rng(0),
+    )[(sat_a, sat_b)]
+
+    assert performance["link_available"] is expected_available
+    assert bool(performance["link_capacity"] > 0.0) is expected_available
+
+
+@pytest.mark.parametrize(("positions_eci", "lowest_altitude", "expected_available"), _EARTH_CLEARANCE_CASES)
+def test_terminal_calculator_enforces_finite_segment_clearance(
+    positions_eci: tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]],
+    lowest_altitude: float,
+    *,
+    expected_available: bool,
+) -> None:
+    sat_a = _make_satellite_terminal(1)
+    sat_b = _make_satellite_terminal(2)
+    calculator = OTC2OTCBinaryCommLinkCalculator(
+        link_capacity=10e9,
+        lowest_altitude=lowest_altitude,
+    )
+    zero = np.zeros(3)
+
+    # Exercise the snapshot kernel directly; separate time-series wrapper defects are tracked in GH issue #210.
+    performance, _ = calculator._calc_satellite_to_satellite(  # noqa: SLF001
+        positions_eci=positions_eci,
+        velocities_eci=(zero, zero),
+        attitude_angular_velocities_eci=(zero, zero),
+        sun_direction_eci=np.array([0.0, 0.0, 1.0]),
+        terminals=(sat_a.terminal, sat_b.terminal),
+        previous_terminal_directions=[(0.0, 0.0), (0.0, 0.0)],
+        time_delta=1.0,
+    )
+
+    assert performance["link_available"] is expected_available
+    assert bool(performance["link_capacity"] > 0.0) is expected_available
 
 
 class TestSatToSatDirectionalSunExclusion:


### PR DESCRIPTION
## Summary

- add a shared finite-segment Earth-clearance predicate
- enforce `EARTH_RADIUS + lowest_altitude` in every supported inter-satellite link calculator
- document and test that exact-threshold clearance is accepted
- add regressions for Earth occultation, configured clearance, and finite-segment behavior

Closes #222.

## Testing

- `just lint`
- `just test` (88 passed, 1 existing XPASS)

## AI assistance

- AI used: yes — an AI coding agent investigated issue #222, implemented the fix, and added tests
- Human review of AI-assisted code: complete

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes; the `breaking change` label is applied
