### PR TITLE
Prevent invisible handover assignments under contention

### DIFF
--- a/src/cosmica/topology/ground_to_constellation.py
+++ b/src/cosmica/topology/ground_to_constellation.py
@@ -198,7 +198,7 @@ def build_manual_g2c_topology(
     return [construct_graph() for _ in range(len(dynamics_data.time))]
 
 
-def build_max_visibility_handover_g2c_topology(  # noqa: C901
+def build_max_visibility_handover_g2c_topology(  # noqa: C901, PLR0912
     constellation: Constellation,
     *,
     ground_nodes: Collection[Gateway | StationaryOnGroundUser],
@@ -270,7 +270,9 @@ def build_max_visibility_handover_g2c_topology(  # noqa: C901
             if sat_idx == -1:
                 continue
             masked_left_visibility_time_step[sat_idx] = 0
-        select_sat_idx[ground_node_idx] = np.argmax(masked_left_visibility_time_step)
+        select_sat_idx[ground_node_idx] = (
+            np.argmax(masked_left_visibility_time_step) if np.any(masked_left_visibility_time_step > 0) else -1
+        )
 
     for time_idx in range(n_time):
         for ground_node_idx, _ground_node in enumerate(ground_nodes_list):
@@ -290,7 +292,8 @@ def build_max_visibility_handover_g2c_topology(  # noqa: C901
                         select_max_visibility_satellite(ground_node_idx, time_idx)
                 else:
                     select_max_visibility_satellite(ground_node_idx, time_idx)
-            link_available[ground_node_idx, select_sat_idx[ground_node_idx], time_idx] = True
+            if select_sat_idx[ground_node_idx] >= 0:
+                link_available[ground_node_idx, select_sat_idx[ground_node_idx], time_idx] = True
 
     def construct_graph(link_available: npt.NDArray[np.bool_]) -> nx.DiGraph:
         graph = nx.Graph()

--- a/tests/topology/test_ground_to_constellation.py
+++ b/tests/topology/test_ground_to_constellation.py
@@ -1,0 +1,100 @@
+import networkx as nx
+import numpy as np
+import numpy.typing as npt
+
+from cosmica.dtos import DynamicsData
+from cosmica.models import CircularSatelliteOrbitModel, Constellation, ConstellationSatellite, Gateway
+from cosmica.topology import build_max_visibility_handover_g2c_topology
+
+type _Satellite = ConstellationSatellite[str, CircularSatelliteOrbitModel]
+type _TopologyFixture = tuple[list[nx.DiGraph], tuple[Gateway[str], ...], tuple[_Satellite, ...]]
+
+
+def _build_topologies(
+    visibility_by_satellite: tuple[tuple[bool, ...], ...],
+    *,
+    n_ground_nodes: int = 1,
+) -> _TopologyFixture:
+    n_time = len(visibility_by_satellite[0])
+    assert all(len(visibility) == n_time for visibility in visibility_by_satellite)
+    time = np.datetime64("2026-01-01") + np.arange(n_time).astype("timedelta64[s]")
+    orbit = CircularSatelliteOrbitModel(
+        semi_major_axis=7_000_000.0,
+        inclination=0.0,
+        raan=0.0,
+        phase_at_epoch=0.0,
+        epoch=time[0],
+    )
+    satellites = tuple(
+        ConstellationSatellite(id=f"satellite-{satellite_index}", orbit=orbit)
+        for satellite_index in range(len(visibility_by_satellite))
+    )
+    constellation = Constellation(satellites=dict(enumerate(satellites)))
+    ground_nodes = tuple(
+        Gateway(id=f"ground-{ground_index}", latitude=0.0, longitude=0.0, minimum_elevation=0.0)
+        for ground_index in range(n_ground_nodes)
+    )
+
+    zero_vectors: dict[_Satellite, npt.NDArray[np.floating]] = {
+        satellite: np.zeros((n_time, 3)) for satellite in satellites
+    }
+    satellite_position_ecef: dict[_Satellite, npt.NDArray[np.floating]] = {
+        satellite: np.column_stack(
+            (
+                np.where(visibility, 7_000_000.0, -7_000_000.0),
+                np.zeros((n_time, 2)),
+            ),
+        )
+        for satellite, visibility in zip(satellites, visibility_by_satellite, strict=True)
+    }
+    dynamics_data = DynamicsData(
+        time=time,
+        dcm_eci2ecef=np.zeros((n_time, 3, 3)),
+        satellite_position_eci=zero_vectors,
+        satellite_velocity_eci=zero_vectors,
+        satellite_position_ecef=satellite_position_ecef,
+        satellite_attitude_angular_velocity_eci=zero_vectors,
+        sun_direction_eci=np.zeros((n_time, 3)),
+        sun_direction_ecef=np.zeros((n_time, 3)),
+    )
+
+    graphs = build_max_visibility_handover_g2c_topology(
+        constellation,
+        ground_nodes=ground_nodes,
+        dynamics_data=dynamics_data,
+    )
+    return graphs, ground_nodes, satellites
+
+
+def test_max_visibility_handover_leaves_contended_ground_node_unassigned() -> None:
+    graphs, ground_nodes, (invisible_satellite, visible_satellite) = _build_topologies(
+        ((False, False, False), (True, True, True)),
+        n_ground_nodes=2,
+    )
+
+    for graph in graphs:
+        assert set(graph.neighbors(ground_nodes[0])) == {visible_satellite}
+        assert set(graph.neighbors(ground_nodes[1])) == set()
+        assert graph.degree[invisible_satellite] == 0
+
+
+def test_max_visibility_handover_leaves_ground_node_without_visibility_unassigned() -> None:
+    graphs, (ground_node,), satellites = _build_topologies(
+        ((False, False, False), (False, False, False)),
+    )
+
+    for graph in graphs:
+        assert set(graph.neighbors(ground_node)) == set()
+        assert all(graph.degree[satellite] == 0 for satellite in satellites)
+
+
+def test_max_visibility_handover_preserves_connection_until_handover() -> None:
+    graphs, (ground_node,), (first_satellite, second_satellite) = _build_topologies(
+        ((True, True, False), (False, True, True)),
+    )
+
+    assert [set(graph.neighbors(ground_node)) for graph in graphs] == [
+        {first_satellite},
+        {first_satellite},
+        {second_satellite},
+    ]


### PR DESCRIPTION
## Summary

- keep a ground node unassigned when contention masks every positive remaining-visibility value, instead of letting `np.argmax` select invisible satellite index 0
- avoid materializing a link for the existing `-1` unassigned sentinel
- add regression coverage for repeated contention, no visibility, and ordinary persistence/handover

Closes #207.

This intentionally leaves PR #193's separate missing-parentheses fix for `.sum()` and issue #224's broader topology refactor untouched.

## AI assistance

- AI used: yes - an autonomous Codex agent reproduced the defect, implemented the focused fix and tests, and ran the validation listed below.
- Human review of AI-assisted code: complete

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes; the `breaking change` label is applied

## Testing

- `uv run --no-sync pytest tests/topology/test_ground_to_constellation.py -q` - 3 passed (the contention case failed before the fix)
- `uv run --no-sync coverage run -m pytest --import-mode importlib` - 75 passed, 1 existing XPASS, 20 snapshots passed
- `uv run --no-sync ruff check`
- `uv run --no-sync mypy .`
- `uv run --no-sync pyrefly check --output-format=github`
- `uv run --no-sync lint-imports`
- `uv run --no-sync deptry .`
- `uv sync --frozen --no-dev --group license` then `uv run --no-sync pip-licenses`
- `$env:PYTHONUTF8='1'; uv run --no-sync mkdocs build`
- `uv build --no-sources`

All commands above passed locally on Windows 11 with CPython 3.14.5. The UTF-8 environment variable is needed because the existing docs generator otherwise reads the UTF-8 README with the Windows cp1252 default. This PR's Linux CI and zizmor jobs have not executed: both GitHub Actions runs are `action_required` pending maintainer approval. The current-main docs workflow at base commit `f8f48bf` passed.
